### PR TITLE
Dev

### DIFF
--- a/config/sync/block.block.views_block__curated_by_the_user_block_1.yml
+++ b/config/sync/block.block.views_block__curated_by_the_user_block_1.yml
@@ -12,7 +12,7 @@ dependencies:
 id: views_block__curated_by_the_user_block_1
 theme: bise
 region: sidebar_second
-weight: 0
+weight: -9
 provider: null
 plugin: 'views_block:curated_by_the_user-block_1'
 settings:

--- a/config/sync/block.block.views_block__what_links_here_block_1.yml
+++ b/config/sync/block.block.views_block__what_links_here_block_1.yml
@@ -1,0 +1,35 @@
+uuid: 35e6873c-0ef5-4665-8414-3740de6d7735
+langcode: en
+status: true
+dependencies:
+  config:
+    - views.view.what_links_here
+  module:
+    - ctools
+    - views
+  theme:
+    - bise
+id: views_block__what_links_here_block_1
+theme: bise
+region: sidebar_second
+weight: -13
+provider: null
+plugin: 'views_block:what_links_here-block_1'
+settings:
+  id: 'views_block:what_links_here-block_1'
+  label: ''
+  provider: views
+  label_display: visible
+  views_label: ''
+  items_per_page: none
+  context_mapping: {  }
+visibility:
+  'entity_bundle:node':
+    id: 'entity_bundle:node'
+    bundles:
+      book: book
+      sample_data: sample_data
+      software: software
+    negate: false
+    context_mapping:
+      node: '@node.node_route_context:node'

--- a/config/sync/core.entity_view_display.node.software.default.yml
+++ b/config/sync/core.entity_view_display.node.software.default.yml
@@ -39,7 +39,6 @@ dependencies:
     - ds
     - image
     - link
-    - taxonomy
     - text
     - user
 third_party_settings:
@@ -116,9 +115,10 @@ content:
   field_free_tagging:
     weight: 18
     label: above
-    settings: {  }
+    settings:
+      link: true
     third_party_settings: {  }
-    type: entity_reference_rss_category
+    type: entity_reference_label
     region: right
   field_give_feedback_on_this_soft:
     weight: 27
@@ -140,9 +140,10 @@ content:
   field_has_biological_terms:
     weight: 17
     label: above
-    settings: {  }
+    settings:
+      link: true
     third_party_settings: {  }
-    type: entity_reference_rss_category
+    type: entity_reference_label
     region: right
   field_has_comparison:
     weight: 25
@@ -190,9 +191,10 @@ content:
   field_has_function:
     weight: 15
     label: above
-    settings: {  }
+    settings:
+      link: true
     third_party_settings: {  }
-    type: entity_reference_rss_category
+    type: entity_reference_label
     region: right
   field_has_implementation:
     weight: 7
@@ -253,9 +255,10 @@ content:
   field_has_topic:
     weight: 16
     label: above
-    settings: {  }
+    settings:
+      link: true
     third_party_settings: {  }
-    type: entity_reference_rss_category
+    type: entity_reference_label
     region: right
   field_has_usage_example:
     weight: 22

--- a/config/sync/core.entity_view_display.node.software.teaser.yml
+++ b/config/sync/core.entity_view_display.node.software.teaser.yml
@@ -15,6 +15,7 @@ dependencies:
     - field.field.node.software.field_has_doi
     - field.field.node.software.field_has_entry_curator
     - field.field.node.software.field_has_function
+    - field.field.node.software.field_has_implementation
     - field.field.node.software.field_has_interaction_level
     - field.field.node.software.field_has_license
     - field.field.node.software.field_has_location
@@ -26,65 +27,99 @@ dependencies:
     - field.field.node.software.field_is_compatible_with
     - field.field.node.software.field_is_covered_by_training_mat
     - field.field.node.software.field_is_dependent_of
+    - field.field.node.software.field_is_using
     - field.field.node.software.field_license_openness
+    - field.field.node.software.field_part_of
     - field.field.node.software.field_platform
     - field.field.node.software.field_supported_image_dimension
     - field.field.node.software.field_type
-    - image.style.thumbnail
     - node.type.software
   module:
-    - image
+    - ds
+    - responsive_image
     - text
     - user
+third_party_settings:
+  ds:
+    layout:
+      id: ds_2col
+      library: ds/ds_2col
+      disable_css: false
+      entity_classes: all_classes
+      settings:
+        wrappers:
+          left: div
+          right: div
+        outer_wrapper: div
+        attributes: ''
+        link_attribute: ''
+        link_custom: ''
+        classes:
+          layout_class: {  }
+    regions:
+      left:
+        - node_title
+        - field_type
+        - body
+        - field_has_topic
+        - field_has_function
+        - links
+      right:
+        - field_image
+    fields:
+      node_title:
+        plugin_id: node_title
+        weight: 0
+        label: hidden
+        formatter: default
 id: node.software.teaser
 targetEntityType: node
 bundle: software
 mode: teaser
 content:
   body:
-    label: hidden
-    type: text_summary_or_trimmed
+    type: text_default
     weight: 2
-    settings:
-      trim_length: 600
+    region: left
+    label: above
+    settings: {  }
     third_party_settings: {  }
-    region: content
   field_has_function:
     type: entity_reference_label
-    weight: 5
-    region: content
-    label: hidden
+    weight: 4
+    region: left
+    label: above
     settings:
       link: true
     third_party_settings: {  }
   field_has_topic:
     type: entity_reference_label
-    weight: 4
-    region: content
-    label: hidden
+    weight: 3
+    region: left
+    label: above
     settings:
       link: true
     third_party_settings: {  }
   field_image:
-    type: image
-    weight: 1
-    region: content
+    type: responsive_image
+    weight: 6
+    region: right
     label: hidden
     settings:
-      image_style: thumbnail
-      image_link: content
+      responsive_image_style: ''
+      image_link: ''
     third_party_settings: {  }
   field_type:
     type: entity_reference_label
-    weight: 3
-    region: content
+    weight: 1
+    region: left
     label: hidden
     settings:
       link: true
     third_party_settings: {  }
   links:
-    weight: 0
-    region: content
+    weight: 5
+    region: left
     settings: {  }
     third_party_settings: {  }
 hidden:
@@ -97,6 +132,7 @@ hidden:
   field_has_documentation: true
   field_has_doi: true
   field_has_entry_curator: true
+  field_has_implementation: true
   field_has_interaction_level: true
   field_has_license: true
   field_has_location: true
@@ -106,6 +142,8 @@ hidden:
   field_is_compatible_with: true
   field_is_covered_by_training_mat: true
   field_is_dependent_of: true
+  field_is_using: true
   field_license_openness: true
+  field_part_of: true
   field_platform: true
   field_supported_image_dimension: true

--- a/config/sync/devel.toolbar.settings.yml
+++ b/config/sync/devel.toolbar.settings.yml
@@ -1,9 +1,9 @@
 toolbar_items:
   - devel.cache_clear
   - devel.container_info.service
+  - devel.route_info.item
   - devel.admin_settings_link
   - devel.execute_php
-  - devel.menu_rebuild
   - devel.reinstall
   - devel.run_cron
 _core:

--- a/config/sync/views.view.recent.yml
+++ b/config/sync/views.view.recent.yml
@@ -5,6 +5,8 @@ dependencies:
   config:
     - field.storage.node.field_image
     - image.style.thumbnail
+    - node.type.book
+    - node.type.sample_data
     - node.type.software
   module:
     - image
@@ -357,65 +359,6 @@ display:
             tags: '0'
           entity_type: node
           plugin_id: taxonomy_index_tid
-        term_node_tid_1:
-          id: term_node_tid_1
-          table: node_field_data
-          field: term_node_tid
-          relationship: none
-          group_type: group
-          admin_label: ''
-          label: Tags
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: true
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          type: ul
-          separator: ', '
-          link_to_taxonomy: true
-          limit: true
-          vids:
-            edam_bioimaging: edam_bioimaging
-            forums: '0'
-            software_artifact: '0'
-            tags: '0'
-          entity_type: node
-          plugin_id: taxonomy_index_tid
       filters:
         status:
           value: '1'
@@ -437,7 +380,9 @@ display:
           admin_label: ''
           operator: in
           value:
+            sample_data: sample_data
             software: software
+            book: book
           group: 1
           exposed: false
           expose:

--- a/config/sync/views.view.trending.yml
+++ b/config/sync/views.view.trending.yml
@@ -294,65 +294,6 @@ display:
             tags: '0'
           entity_type: node
           plugin_id: taxonomy_index_tid
-        term_node_tid_1:
-          id: term_node_tid_1
-          table: node_field_data
-          field: term_node_tid
-          relationship: none
-          group_type: group
-          admin_label: ''
-          label: Tags
-          exclude: false
-          alter:
-            alter_text: false
-            text: ''
-            make_link: false
-            path: ''
-            absolute: false
-            external: false
-            replace_spaces: false
-            path_case: none
-            trim_whitespace: false
-            alt: ''
-            rel: ''
-            link_class: ''
-            prefix: ''
-            suffix: ''
-            target: ''
-            nl2br: false
-            max_length: 0
-            word_boundary: true
-            ellipsis: true
-            more_link: false
-            more_link_text: ''
-            more_link_path: ''
-            strip_tags: false
-            trim: false
-            preserve_tags: ''
-            html: false
-          element_type: ''
-          element_class: ''
-          element_label_type: ''
-          element_label_class: ''
-          element_label_colon: true
-          element_wrapper_type: ''
-          element_wrapper_class: ''
-          element_default_classes: true
-          empty: ''
-          hide_empty: false
-          empty_zero: false
-          hide_alter_empty: true
-          type: ul
-          separator: ', '
-          link_to_taxonomy: true
-          limit: true
-          vids:
-            edam_bioimaging: edam_bioimaging
-            forums: '0'
-            software_artifact: '0'
-            tags: '0'
-          entity_type: node
-          plugin_id: taxonomy_index_tid
       filters:
         status:
           value: '1'

--- a/config/sync/views.view.what_links_here.yml
+++ b/config/sync/views.view.what_links_here.yml
@@ -1,0 +1,314 @@
+uuid: ebb99325-6c6b-4cbc-9770-a7fa34e640ad
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_type
+  module:
+    - eva
+    - node
+    - user
+id: what_links_here
+label: 'what links here'
+module: views
+description: ''
+tag: ''
+base_table: node_field_data
+base_field: nid
+core: 8.x
+display:
+  default:
+    display_plugin: default
+    id: default
+    display_title: Master
+    position: 0
+    display_options:
+      access:
+        type: perm
+        options:
+          perm: 'access content'
+      cache:
+        type: tag
+        options: {  }
+      query:
+        type: views_query
+        options:
+          disable_sql_rewrite: false
+          distinct: false
+          replica: false
+          query_comment: ''
+          query_tags: {  }
+      exposed_form:
+        type: basic
+        options:
+          submit_button: Apply
+          reset_button: false
+          reset_button_label: Reset
+          exposed_sorts_label: 'Sort by'
+          expose_sort_order: true
+          sort_asc_label: Asc
+          sort_desc_label: Desc
+      pager:
+        type: some
+        options:
+          items_per_page: 5
+          offset: 0
+      style:
+        type: default
+      row:
+        type: fields
+        options:
+          default_field_elements: true
+          inline:
+            title: title
+            field_type: field_type
+          separator: /
+          hide_empty: false
+      fields:
+        title:
+          id: title
+          table: node_field_data
+          field: title
+          settings:
+            link_to_entity: true
+          plugin_id: field
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: true
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: value
+          type: string
+          group_column: value
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+        field_type:
+          id: field_type
+          table: node__field_type
+          field: field_type
+          relationship: none
+          group_type: group
+          admin_label: ''
+          label: ''
+          exclude: false
+          alter:
+            alter_text: false
+            text: ''
+            make_link: false
+            path: ''
+            absolute: false
+            external: false
+            replace_spaces: false
+            path_case: none
+            trim_whitespace: false
+            alt: ''
+            rel: ''
+            link_class: ''
+            prefix: ''
+            suffix: ''
+            target: ''
+            nl2br: false
+            max_length: 0
+            word_boundary: true
+            ellipsis: true
+            more_link: false
+            more_link_text: ''
+            more_link_path: ''
+            strip_tags: false
+            trim: false
+            preserve_tags: ''
+            html: false
+          element_type: ''
+          element_class: ''
+          element_label_type: ''
+          element_label_class: ''
+          element_label_colon: false
+          element_wrapper_type: ''
+          element_wrapper_class: ''
+          element_default_classes: true
+          empty: ''
+          hide_empty: false
+          empty_zero: false
+          hide_alter_empty: true
+          click_sort_column: target_id
+          type: entity_reference_label
+          settings:
+            link: true
+          group_column: target_id
+          group_columns: {  }
+          group_rows: true
+          delta_limit: 0
+          delta_offset: 0
+          delta_reversed: false
+          delta_first_last: false
+          multi_type: separator
+          separator: ', '
+          field_api_classes: false
+          plugin_id: field
+      filters:
+        status:
+          value: '1'
+          table: node_field_data
+          field: status
+          plugin_id: boolean
+          entity_type: node
+          entity_field: status
+          id: status
+          expose:
+            operator: ''
+          group: 1
+      sorts:
+        created:
+          id: created
+          table: node_field_data
+          field: created
+          order: DESC
+          entity_type: node
+          entity_field: created
+          plugin_id: date
+          relationship: none
+          group_type: group
+          admin_label: ''
+          exposed: false
+          expose:
+            label: ''
+          granularity: second
+      title: Uses/Contains
+      header: {  }
+      footer: {  }
+      empty: {  }
+      relationships: {  }
+      arguments:
+        field_part_of_target_id:
+          id: field_part_of_target_id
+          table: node__field_part_of
+          field: field_part_of_target_id
+          relationship: none
+          group_type: group
+          admin_label: ''
+          default_action: default
+          exception:
+            value: all
+            title_enable: false
+            title: All
+          title_enable: false
+          title: ''
+          default_argument_type: node
+          default_argument_options: {  }
+          default_argument_skip_url: false
+          summary_options:
+            base_path: ''
+            count: true
+            items_per_page: 25
+            override: false
+          summary:
+            sort_order: asc
+            number_of_records: 0
+            format: default_summary
+          specify_validation: false
+          validate:
+            type: none
+            fail: 'not found'
+          validate_options: {  }
+          break_phrase: false
+          not: false
+          plugin_id: numeric
+      display_extenders: {  }
+      use_more: false
+      use_more_always: true
+      use_more_text: more
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_type'
+  block_1:
+    display_plugin: block
+    id: block_1
+    display_title: Block
+    position: 1
+    display_options:
+      display_extenders: {  }
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_type'
+  entity_view_1:
+    display_plugin: entity_view
+    id: entity_view_1
+    display_title: EVA
+    position: 2
+    display_options:
+      display_extenders: {  }
+      entity_type: node
+      bundles:
+        - software
+      show_title: true
+      title: Uses
+    cache_metadata:
+      max-age: -1
+      contexts:
+        - 'languages:language_content'
+        - 'languages:language_interface'
+        - url
+        - 'user.node_grants:view'
+        - user.permissions
+      tags:
+        - 'config:field.storage.node.field_type'


### PR DESCRIPTION

- Adjusted teaser for software types, now depends on the Display Suite two-column layout
- Added "Uses / Contains" block in software, teaching material, data content types to reveal relationship between components, workflows and collections