### PR TITLE
A small title fix

### DIFF
--- a/config/sync/block.block.bise.yml
+++ b/config/sync/block.block.bise.yml
@@ -16,7 +16,7 @@ provider: null
 plugin: 'block_content:fd094f86-753a-4ddf-be9f-0b74a064e0bc'
 settings:
   id: 'block_content:fd094f86-753a-4ddf-be9f-0b74a064e0bc'
-  label: 'BISE Bio Imaging Search Engine: a  Bio Image Information Index'
+  label: 'BISE Bioimage Informatics Search Engine: a BioImage Informatics Index'
   provider: block_content
   label_display: visible
   status: true

--- a/config/sync/system.site.yml
+++ b/config/sync/system.site.yml
@@ -1,7 +1,7 @@
 uuid: f424cf9d-8948-4c5a-b459-4d637a455122
 name: BISE
 mail: perrine.paul-gilloteaux@univ-nantes.fr
-slogan: 'BioImage Informatics Search Engine'
+slogan: 'Bioimage Informatics Search Engine'
 page:
   403: ''
   404: ''


### PR DESCRIPTION
Copied from 08917bb:
> 1. For consistency with config/sync/system.site.yml (Bioimage Informatics Search Engine)
> 2. For gramatical correctness ('bio image' separately is wrong)
> 3. For factual correctness (is not about bioimage information, but about bioimage analysis and, more generally, bioimage informatics)
> 4. For consistency with the BIII abbreviation (BioImage Informatics Index)
> 5. For testing the new development workflow! :-D
 