### PR TITLE
drupal core version setting updated to 8.6.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -40,7 +40,7 @@
         "drupal/chosen": "^2.5",
         "drupal/console": "^1.0.2",
         "drupal/contribute": "^5.0@beta",
-        "drupal/core": "^8.6.0",
+        "drupal/core": "8.6.*",
         "drupal/ctools": "^3.0",
         "drupal/devel": "^1.2",
         "drupal/ds": "^3.1",

--- a/web/.htaccess
+++ b/web/.htaccess
@@ -132,6 +132,8 @@ AddEncoding gzip svgz
   RewriteRule ^core/install.php core/install.php?rewrite=ok [QSA,L]
 
 # Redirect request to image files under /sites/default/files/ to the production server. (Kota)
+  #RewriteCond %{HTTP_REFERER} !^https://biii\.eu
+  #RewriteCond %{HTTP_REFERER} !^http://biii\.eu
   RewriteRule ^(sites/default/files/.*\.(?:jpg|jpeg|JPG|png|PNG|gif|GIF|txt|csv|ico))$ https://biii.eu/$1 [L]
 
   # Pass all requests not referring directly to files in the filesystem to


### PR DESCRIPTION
in composer.json, drupal core version was set to "^8.6.0" but to allow dev versions, it was changed to "8.6.*". at the moment, this dev branch is at the same status as `master`and `production`